### PR TITLE
Fix utf-8 encoding error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if sys.argv[-1] == 'tag':
     sys.exit()
 
 
-readme = open('README.rst').read()
+readme = open('README.rst', 'rt', encoding='UTF-8').read()
 
 setup(
     name='django-responsive2',


### PR DESCRIPTION
when open `README.rst` file, get Error
```
UnicodeDecodeError: 'cp949' codec can't decode byte 0xe2 in position 3760: illegal multibyte sequence
```